### PR TITLE
update rancher to include data sources for vpc and route53

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,24 @@ terraform {
     profile = "Webmod-Admin"
   }
 }
-
+data "terraform_remote_state" "vpc" {
+  backend = "s3"
+  config = {
+    bucket  = "webmod-tfstate"
+    key     = "infra/network"
+    region  = "us-east-1"
+    profile = var.profile
+  }
+}
+data "terraform_remote_state" "route53" {
+  backend = "s3"
+  config = {
+    bucket  = "webmod-tfstate"
+    key     = "infra/route53"
+    region  = "us-east-1"
+    profile = var.profile
+  }
+}
 provider "aws" {
   region = var.aws_region
   profile = var.profile

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+ output "rancher_private_ip" {
+   value = aws_instance.rancher_server.private_ip
+ }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,21 +1,17 @@
 # General AWS variables
 aws_region    = "us-east-1"
 profile       = "Webmod-Admin"
-name          = "webmod-rancher"
-instance_type = "t3a.medium"
-key_name      = "webmod-rancher"
 tags = {
   Terraform   = "true"
   Team        = "Webmod"
   Environment = "dev"
 }
 
-# VPC variables
-vpc_id          = "vpc-03dc11277661baafb"
-subnet_id       = "subnet-09dee7714b308cd9a" // Private subnet 1
+name          = "webmod"
+key_name      = "webmod-rancher"
+instance_type = "t3a.medium"
 
 # Rancher variables
-private_ip           = "10.0.0.25"
 docker_version       = "20.10"
 k3s_version          = "v1.21.5+k3s1"
 cert_manager_version = "v1.6.1"

--- a/variables.tf
+++ b/variables.tf
@@ -7,15 +7,7 @@ variable "profile" {
   type        = string
 }
 variable "name" {
-  description = "name prefix used for all resources"
-  type        = string
-}
-variable "vpc_id" {
-  description = "VPC id used for all resources"
-  type        = string
-}
-variable "subnet_id" {
-  description = "Subnet id used to deploy Rancher resources"
+  description = "name and/or name prefix for all resources"
   type        = string
 }
 variable "tags" {
@@ -33,10 +25,6 @@ variable "instance_username" {
 }
 variable "key_name" {
   description = "ssh keypair name"
-  type        = string
-}
-variable "private_ip" {
-  description = "private ip used for single-node rancher server"
   type        = string
 }
 variable "docker_version" {


### PR DESCRIPTION
This PR modifies the terraform code to use vpc and route53 resources provision by terraform using SteampunkFoundry terraform-route53 and terraform-vpc repositories, specifically the webmod branches.

- Add route 53 hosted zone data resource
- Add vpc data resource
- Provision ssh key pair and upload to secrets manager
- Update null resources and add local file to use provisioned ssh key pair
- add route53 record rancher.webmod.private to resolve to rancher server ip
- remove vpc_id and subnet_id variables